### PR TITLE
fix #1581 mongodb connection got killed

### DIFF
--- a/src/mongoc/mc_topology.erl
+++ b/src/mongoc/mc_topology.erl
@@ -256,7 +256,7 @@ drop_server(Topology, Server) ->
   gen_server:cast(Topology, {drop_server, Server}).
 
 %% @private
-parse_seeds({single, Addr}) -> {single, undefined, [Addr]};
+parse_seeds({single, Addr}) -> {single, undefined, Addr};
 parse_seeds({unknown, Seeds}) -> {unknown, undefined, Seeds};
 parse_seeds({sharded, Seeds}) -> {sharded, undefined, Seeds};
 parse_seeds({rs, SetName, Seeds}) -> {replicaSetNoPrimary, SetName, Seeds};

--- a/src/mongoc/mc_topology_logics.erl
+++ b/src/mongoc/mc_topology_logics.erl
@@ -95,7 +95,7 @@ update_topology_state(
     State = #topology_state{setName = undefined, topology_opts = Topts, worker_opts = Wopts, servers = Tab}) ->
   HostsList = lists:flatten([Hosts, Arbiters, Passives]),
   init_seeds(HostsList, Tab, Topts, Wopts),
-  stop_servers_not_in_list(HostsList, Tab),
+  %stop_servers_not_in_list(HostsList, Tab),
   State#topology_state{setName = SetName, maxElectionId = ElectionId, type = checkIfHasPrimary(Tab)};
 update_topology_state(#mc_server{type = rsPrimary, pid = Pid, host = Host, setName = SSetName},
     State = #topology_state{setName = CSetName, servers = Tab}) when SSetName =/= CSetName ->


### PR DESCRIPTION
If one of `auth.mongo.server` configured in emq_auth_mongo.conf doesn't exist in db.isMaster().hosts, lots of errors will be printed:

```
[error] gen_server <0.1448.0> terminated with reason: killed
```